### PR TITLE
Tilføjet chevron-right i white udgave til når man benytter i-tag med …

### DIFF
--- a/src/img/svg-icons/chevron-right-white.svg
+++ b/src/img/svg-icons/chevron-right-white.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path fill="#fff" d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z" /></svg>

--- a/src/stylesheets/elements/_icons.scss
+++ b/src/stylesheets/elements/_icons.scss
@@ -12,6 +12,7 @@ $icons: (
     "check-circle-outline",
     "chevron-left",
     "chevron-right",
+    "chevron-right-white",
     "close",
     "close-circle",
     "close-circle-outline",


### PR DESCRIPTION
Tilføjet chevron-right i white udgave til når man benytter i-tag med class i stedet for svg-tag.

Hvis det kan gøren på anden vis via style class, så gerne oplys det i stedet for at merge :-)