### PR TITLE
Add repository link to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "scripts": {
     "build": "webpack"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/detfaellesdesignsystem/dkfds-components.git"
+  },
   "author": "Erhvervsstyrelsen og Digitaliseringsstyrelsen",
   "license": "(MIT AND OFL-1.1 AND Apache-2.0)",
   "devDependencies": {


### PR DESCRIPTION
This makes the link appear on the right-hand side of the npmjs.com page for the package, making it easier to find.