### PR TITLE
Expose all colors as utility classes

### DIFF
--- a/src/stylesheets/core/utilities/_background.scss
+++ b/src/stylesheets/core/utilities/_background.scss
@@ -1,5 +1,6 @@
 @use "../../variables" as vars;
 @use "../../functions" as func;
+@use "../../values" as vals;
 
 // Generates utility classes to control width in percent. 
 // Example: .w-percent-100 .w-percent-md-30
@@ -15,5 +16,15 @@ $backgroundcolors: (
   .bg-#{$name} { 
     background: func.color($color) !important; 
     background-color: func.color($color) !important;
+  }
+}
+
+@each $name, $color in vals.$all-colors {
+  .bg-#{$name} {
+    background-color: func.color($color) !important;
+  }
+
+  .color-#{$name} {
+    color: func.color($color) !important;
   }
 }


### PR DESCRIPTION
Her er et forslag om at gøre de indbyggede farver tilgængelige som utility classes hhv `.bg-{farve}` og `.color-{farve}`.

Vi ender i vores brug af designsystemet ofte med at skulle slå farver op for at bruge dem forskellige steder. Det gør det svært hvis vi skifter farverne ud eller justerer på dem. Så skal vi finde alle de steder vi har refereret til dem for at justere.

Tilgangen jeg foreslår minder om f.eks. Tailwinds farve utility classes.

Sig gerne til hvis I har årsager for eller imod tilgangen, jeg justerer meget gerne - det her er bare for at illustrere muligheden.